### PR TITLE
Print pid and thread-id in verbose-mode.

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -79,6 +79,7 @@ public class Main {
         commandLine.parseArgs(args);
         Logger.NO_COLOR = baseCommand.noColor;
         Logger.NO_EMOJIS = !baseCommand.emojis;
+        Logger.PRINT_THREAD = baseCommand.verbose;
         int exitCode = commandLine.execute(args);
         System.exit(exitCode);
     }

--- a/src/main/java/net/neoforged/neoform/runtime/utils/Logger.java
+++ b/src/main/java/net/neoforged/neoform/runtime/utils/Logger.java
@@ -13,6 +13,7 @@ public final class Logger {
 
     public static boolean NO_COLOR;
     public static boolean NO_EMOJIS;
+    public static boolean PRINT_THREAD;
     private static IndeterminateSpinner spinner;
 
     public static Logger create() {
@@ -21,6 +22,13 @@ public final class Logger {
 
     public void println(String text) {
         closeSpinner();
+
+        // Print a process-id and thread-id to help identify concurrently running instances of NFRT in verbose mode
+        if (PRINT_THREAD) {
+            System.out.print(
+                    cleanText(AnsiColor.MUTED + "[" + ProcessHandle.current().pid() + ":" + Thread.currentThread().threadId() + "] " + AnsiColor.RESET)
+            );
+        }
 
         System.out.println(cleanText(text));
     }


### PR DESCRIPTION
Example output:

```
[964:45]  Acquired lock for recompile_15e2dce053c364dd8760c1f692d421027ffc4d80
[964:45]  REUSE Used cache of recompile in 0.00s
[964:1] Total runtime: 0.88s
```