### PR TITLE
Add an option to validate ATs

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
@@ -52,6 +52,9 @@ public class RunNeoFormCommand extends NeoFormEngineCommand {
     @CommandLine.Option(names = "--access-transformer", arity = "*")
     List<String> additionalAccessTransformers = new ArrayList<>();
 
+    @CommandLine.Option(names = "--validate-access-transformers", description = "Whether access transformers should be validated and fatal errors should arise if they target members that do not exist")
+    boolean validateAccessTransformers;
+
     @CommandLine.Option(names = "--parchment-data", description = "Path or Maven coordinates of parchment data to use")
     String parchmentData;
 
@@ -132,6 +135,9 @@ public class RunNeoFormCommand extends NeoFormEngineCommand {
         if (!additionalAccessTransformers.isEmpty()) {
             var transformSources = getOrAddTransformSourcesNode(engine);
             transformSources.setAdditionalAccessTransformers(additionalAccessTransformers.stream().map(Paths::get).toList());
+            if (validateAccessTransformers) {
+                transformSources.addArg("--access-transformer-validation=error");
+            }
         }
 
         if (parchmentData != null) {


### PR DESCRIPTION
This PR adds a `--validate-access-transformers` option that, when enabled, will make JST fatally error when ATs do not have a valid target.