### PR TITLE
Add detection of MC launcher installations and reuse libraries stored there

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,61 +15,6 @@ Listing.
 
 ## Usage
 
-### Common Options
-
-These options affect all NFRT subcommands.
-
-#### Set NFRT Home Directory
-
-The `--home-dir` option changes where NFRT stores its caches, intermediate working directories, assets, etc.
-
-It defaults to `.neoformruntime` in your user directory on Windows and Mac OS X, and `.cache/neoformruntime` on Linux,
-where it also respects `XDG_CACHE_DIR`.
-
-#### Change Temporary Working Directories
-
-The `--work-dir` option changes where NFRT creates temporary working directories.
-Defaults to the given home directory, otherwise.
-
-#### Adding Custom Launcher Directories
-
-NFRT will try to reuse files found in Minecraft launcher directories. It will scan known locations to find installation
-directories.
-If you have moved your launcher, you can supply additional launcher directories using the `--launcher-dir` option.
-
-#### Artifact Resolution
-
-NFRT comes with built-in Maven repositories for downloading required files.
-To override these repositories, use the `--repository` option one or more times.
-If you'd only like to add repositories instead of overriding them completely, you can use the `--add-repository` option.
-
-When running NFRT through a tool like Gradle, it might be desired to externally inject all needed dependencies,
-by redirecting them to the local Gradle artifact cache.
-NFRT supports this use case by supporting an artifact manifest, which can be supplied using the `--artifact-manifest`
-option.
-
-This manifest is a Java properties file in ISO-8859-1 encoding, which uses a Maven coordinate as the key and the full
-path for that artifact as the value. For example: 
-
-`com.google.guava\:guava\:32.1.2-jre=C\:\\path\\to\\file.jar`
-
-To aid with detecting missing entries to fully cover all required artifacts, the `--warn-on-artifact-manifest-miss`
-option
-enables warnings when an artifact is being looked up, but not found in the manifest.
-NFRT will continue to download the artifact remotely in this case.
-
-#### Mojang Launcher Manifest
-
-The full URL to the [Launcher version manifest](https://launchermeta.mojang.com/mc/game/version_manifest_v2.json) can be overridden using `--launcher-meta-uri`.
-
-#### Output Settings
-
-For more verbose output, pass `--verbose`.
-
-To force the use of ANSI color on the console, pass `--color`, or `--no-color` to disable it. The `NO_COLOR` environment variable is also respected.
-
-The use of Emojis in console output can be toggled with `--emojis` and `--no-emojis`.
-
 ### run: Creating Minecraft Artifacts
 
 This is the primary use of the NeoForm Runtime. For a given NeoForge or NeoForm version, it will build
@@ -141,39 +86,60 @@ assets_root=...path to assets...
 While it may seem odd that NFRT supports passing NeoForm or NeoForge versions to this command, this is in service
 of potential Gradle plugins never having to actually read and parse the NeoForm configuration file.
 
-## Caches
+## Common Options
 
-NFRT has to store various files to speed up later runs. It does this in several cache
+These options affect all NFRT subcommands.
+
+### Set NFRT Home Directory
+
+The `--home-dir` option changes where NFRT stores its caches, intermediate working directories, assets, etc.
+
+It defaults to `.neoformruntime` in your user directory on Windows and Mac OS X, and `.cache/neoformruntime` on Linux,
+where it also respects `XDG_CACHE_DIR`.
+
+### Change Temporary Working Directories
+
+The `--work-dir` option changes where NFRT creates temporary working directories.
+Defaults to the given home directory, otherwise.
+
+### Adding Custom Launcher Directories
+
+NFRT will try to reuse files found in Minecraft launcher directories. It will scan known locations to find installation
 directories.
+If you have moved your launcher, you can supply additional launcher directories using the `--launcher-dir` option.
 
-### Cache Directories
+### Artifact Resolution
 
-On Linux, NFRT will store its caches by default at `$XDG_CACHE_HOME/neoformruntime`. If that variable is not set or not
-an
-absolute path, it falls back to `~/.cache/neoformruntime`.
+NFRT comes with built-in Maven repositories for downloading required files.
+To override these repositories, use the `--repository` option one or more times.
+If you'd only like to add repositories instead of overriding them completely, you can use the `--add-repository` option.
 
-For other operating systems (Windows, Mac), it defaults to `.neoformruntime` in your home directory.
+When running NFRT through a tool like Gradle, it might be desired to externally inject all needed dependencies,
+by redirecting them to the local Gradle artifact cache.
+NFRT supports this use case by supporting an artifact manifest, which can be supplied using the `--artifact-manifest`
+option.
 
-Please note that Gradle plugins using this runtime may set different cache directories.
+This manifest is a Java properties file in ISO-8859-1 encoding, which uses a Maven coordinate as the key and the full
+path for that artifact as the value. For example:
 
-### Reusing Gradle Artifacts
+`com.google.guava\:guava\:32.1.2-jre=C\:\\path\\to\\file.jar`
 
-To prevent NFRT from re-downloading all the libraries and artifacts **again** when it is being used through Gradle,
-it supports passing an "artifact manifest". This property file maps from Maven coordinates to the full path of
-those files on disk.
+To aid with detecting missing entries to fully cover all required artifacts, the `--warn-on-artifact-manifest-miss`
+option
+enables warnings when an artifact is being looked up, but not found in the manifest.
+NFRT will continue to download the artifact remotely in this case.
 
-The path to this manifest is passed to NFRT via the `--artifact-manifest` command-line option.
+### Mojang Launcher Manifest
 
-Example:
+The full URL to the [Launcher version manifest](https://launchermeta.mojang.com/mc/game/version_manifest_v2.json) can be overridden using `--launcher-meta-uri`.
 
-```properties
-net.neoforged.fancymodloader\:loader\:3.0.53-pr-54-junit=C\:\\Gradle Home\\caches\\modules-2\\files-2.1\\net.neoforged.fancymodloader\\loader\\3.0.53-pr-54-junit\\eacd6fc41449ff1dc84b1a4593c7e6c96599374f\\loader-3.0.53-pr-54-junit.jar
-[...]
-```
+### Output Settings
 
-The Gradle plugin can prepare such a file to make NFRT use a local build of certain artifacts too in case includeBuild
-is used on the
-containing project.
+For more verbose output, pass `--verbose`.
+
+To force the use of ANSI color on the console, pass `--color`, or `--no-color` to disable it. The `NO_COLOR` environment variable is also respected.
+
+The use of Emojis in console output can be toggled with `--emojis` and `--no-emojis`.
 
 ## Example Execution Graphs
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,65 @@ Since it is used as part of the NeoForge toolchain, it extends NeoForm by adding
 apply [NeoForge](https://github.com/neoforged/NeoForge) patches and produces the necessary artifacts to compile against
 the NeoForge APIs.
 
-You'll find the [latest releases](https://projects.neoforged.net/neoforged/neoformruntime) on the NeoForged Project Listing.
+You'll find the [latest releases](https://projects.neoforged.net/neoforged/neoformruntime) on the NeoForged Project
+Listing.
 
 ## Usage
+
+### Common Options
+
+These options affect all NFRT subcommands.
+
+#### Set NFRT Home Directory
+
+The `--home-dir` option changes where NFRT stores its caches, intermediate working directories, assets, etc.
+
+It defaults to `.neoformruntime` in your user directory on Windows and Mac OS X, and `.cache/neoformruntime` on Linux,
+where it also respects `XDG_CACHE_DIR`.
+
+#### Change Temporary Working Directories
+
+The `--work-dir` option changes where NFRT creates temporary working directories.
+Defaults to the given home directory, otherwise.
+
+#### Adding Custom Launcher Directories
+
+NFRT will try to reuse files found in Minecraft launcher directories. It will scan known locations to find installation
+directories.
+If you have moved your launcher, you can supply additional launcher directories using the `--launcher-dir` option.
+
+#### Artifact Resolution
+
+NFRT comes with built-in Maven repositories for downloading required files.
+To override these repositories, use the `--repository` option one or more times.
+If you'd only like to add repositories instead of overriding them completely, you can use the `--add-repository` option.
+
+When running NFRT through a tool like Gradle, it might be desired to externally inject all needed dependencies,
+by redirecting them to the local Gradle artifact cache.
+NFRT supports this use case by supporting an artifact manifest, which can be supplied using the `--artifact-manifest`
+option.
+
+This manifest is a Java properties file in ISO-8859-1 encoding, which uses a Maven coordinate as the key and the full
+path for that artifact as the value. For example: 
+
+`com.google.guava\:guava\:32.1.2-jre=C\:\\path\\to\\file.jar`
+
+To aid with detecting missing entries to fully cover all required artifacts, the `--warn-on-artifact-manifest-miss`
+option
+enables warnings when an artifact is being looked up, but not found in the manifest.
+NFRT will continue to download the artifact remotely in this case.
+
+#### Mojang Launcher Manifest
+
+The full URL to the [Launcher version manifest](https://launchermeta.mojang.com/mc/game/version_manifest_v2.json) can be overridden using `--launcher-meta-uri`.
+
+#### Output Settings
+
+For more verbose output, pass `--verbose`.
+
+To force the use of ANSI color on the console, pass `--color`, or `--no-color` to disable it. The `NO_COLOR` environment variable is also respected.
+
+The use of Emojis in console output can be toggled with `--emojis` and `--no-emojis`.
 
 ### run: Creating Minecraft Artifacts
 
@@ -92,7 +148,8 @@ directories.
 
 ### Cache Directories
 
-On Linux, NFRT will store its caches by default at `$XDG_CACHE_HOME/neoformruntime`. If that variable is not set or not an
+On Linux, NFRT will store its caches by default at `$XDG_CACHE_HOME/neoformruntime`. If that variable is not set or not
+an
 absolute path, it falls back to `~/.cache/neoformruntime`.
 
 For other operating systems (Windows, Mac), it defaults to `.neoformruntime` in your home directory.
@@ -114,9 +171,9 @@ net.neoforged.fancymodloader\:loader\:3.0.53-pr-54-junit=C\:\\Gradle Home\\cache
 [...]
 ```
 
-The Gradle plugin can prepare such a file to make NFRT use a local build of certain artifacts too in case includeBuild is used on the 
+The Gradle plugin can prepare such a file to make NFRT use a local build of certain artifacts too in case includeBuild
+is used on the
 containing project.
-
 
 ## Example Execution Graphs
 

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
@@ -85,6 +85,7 @@ public class ArtifactManager {
                     return getArtifactFromPath(localPath);
                 }
             } catch (IOException ignored) {
+                // Ignore if it doesn't exist or is otherwise fails to be read
             }
         }
 

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
@@ -199,7 +199,7 @@ public class ArtifactManager {
 
         // NOTE: we're not reusing launcher manifests, since we don't know how old they are
 
-       var finalLocation = artifactsCache.resolve("minecraft_launcher_manifest.json");
+        var finalLocation = artifactsCache.resolve("minecraft_launcher_manifest.json");
 
         downloadManager.download(DownloadSpec.of(launcherManifestUrl), finalLocation);
 

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
@@ -198,7 +198,8 @@ public class ArtifactManager {
      */
     public Artifact getLauncherManifest() throws IOException {
 
-        // NOTE: we're not reusing launcher manifests, since we don't know how old they are
+        // Note that we're not reusing launcher manifests from known launcher installations,
+        // since we don't know how old they are
 
         var finalLocation = artifactsCache.resolve("minecraft_launcher_manifest.json");
 

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
@@ -1,6 +1,7 @@
 package net.neoforged.neoform.runtime.artifacts;
 
 import net.neoforged.neoform.runtime.cache.CacheManager;
+import net.neoforged.neoform.runtime.cache.LauncherInstallations;
 import net.neoforged.neoform.runtime.cli.LockManager;
 import net.neoforged.neoform.runtime.downloads.DownloadManager;
 import net.neoforged.neoform.runtime.downloads.DownloadSpec;
@@ -10,6 +11,7 @@ import net.neoforged.neoform.runtime.manifests.MinecraftLibrary;
 import net.neoforged.neoform.runtime.manifests.MinecraftVersionManifest;
 import net.neoforged.neoform.runtime.utils.AnsiColor;
 import net.neoforged.neoform.runtime.utils.FilenameUtil;
+import net.neoforged.neoform.runtime.utils.HashingUtil;
 import net.neoforged.neoform.runtime.utils.Logger;
 import net.neoforged.neoform.runtime.utils.MavenCoordinate;
 
@@ -28,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 public class ArtifactManager {
@@ -41,17 +44,20 @@ public class ArtifactManager {
     private final Path artifactsCache;
     private final Map<MavenCoordinate, Artifact> externallyProvided = new HashMap<>();
     private boolean warnOnArtifactManifestMiss;
+    private final LauncherInstallations launcherInstallations;
 
     public ArtifactManager(List<URI> repositoryBaseUrls,
                            CacheManager cacheManager,
                            DownloadManager downloadManager,
                            LockManager lockManager,
-                           URI launcherManifestUrl) {
+                           URI launcherManifestUrl,
+                           LauncherInstallations launcherInstallations) {
         this.repositoryBaseUrls = repositoryBaseUrls;
         this.downloadManager = downloadManager;
         this.lockManager = lockManager;
         this.launcherManifestUrl = launcherManifestUrl;
         this.artifactsCache = cacheManager.getArtifactCacheDir();
+        this.launcherInstallations = launcherInstallations;
     }
 
     public Artifact get(MinecraftLibrary library) throws IOException {
@@ -60,15 +66,29 @@ public class ArtifactManager {
             throw new IllegalArgumentException("Cannot download a library that has no artifact defined: " + library);
         }
 
-        // TODO: if we identify where the Minecraft installation is, we could try to copy the library from there
-
         var artifactCoordinate = MavenCoordinate.parse(library.artifactId());
         var externalArtifact = getFromExternalManifest(artifactCoordinate);
         if (externalArtifact != null) {
             return externalArtifact;
         }
 
-        var finalLocation = artifactsCache.resolve(artifactCoordinate.toRelativeRepositoryPath());
+        var relativePath = artifactCoordinate.toRelativeRepositoryPath();
+
+        // Try reusing it from a local Minecraft installation, which ultimately is structured like a Maven repo
+        var localMinecraftLibraries = new ArrayList<>(launcherInstallations.getLibraryDirectories());
+        for (var localRepo : localMinecraftLibraries) {
+            var localPath = localRepo.resolve(relativePath);
+            try {
+                // Ensure the file matches
+                var fileHash = HashingUtil.hashFile(localPath, "SHA-1");
+                if (Objects.equals(fileHash, library.downloads().artifact().checksum())) {
+                    return getArtifactFromPath(localPath);
+                }
+            } catch (IOException ignored) {
+            }
+        }
+
+        var finalLocation = artifactsCache.resolve(relativePath);
 
         return download(finalLocation, artifact);
     }
@@ -228,10 +248,6 @@ public class ArtifactManager {
         return new Artifact(path, attrView.lastModifiedTime().toMillis(), attrView.size());
     }
 
-    public DownloadManager getDownloadManager() {
-        return downloadManager;
-    }
-
     @FunctionalInterface
     public interface DownloadAction {
         void run() throws IOException;
@@ -283,10 +299,6 @@ public class ArtifactManager {
 
     private Artifact download(Path finalLocation, DownloadSpec spec) throws IOException {
         return download(finalLocation, () -> downloadManager.download(spec, finalLocation));
-    }
-
-    public boolean isWarnOnArtifactManifestMiss() {
-        return warnOnArtifactManifestMiss;
     }
 
     public void setWarnOnArtifactManifestMiss(boolean warnOnArtifactManifestMiss) {

--- a/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
@@ -38,7 +38,7 @@ public class LauncherInstallations {
 
     private final List<LauncherDirectory> launcherDirectories = new ArrayList<>();
 
-    // If true, the scan was already performed and launcherDirectories is up-to-date
+    /** If true, the scan was already performed and launcherDirectories is up-to-date */
     private boolean scanned;
 
     private boolean verbose;

--- a/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
@@ -28,6 +28,7 @@ public class LauncherInstallations {
             "${user.home}/Library/Application Support/minecraft/", // macOS, default launcher
             "${user.home}/curseforge/minecraft/Install/", // Windows, Curseforge Client
             "${env.APPDATA}/com.modrinth.theseus/meta/", // Windows, Modrinth App
+            "${env.LOCALAPPDATA}/.ftba/bin/", // Windows, FTB App
             "${user.home}/.local/share/PrismLauncher/", // linux, PrismLauncher
             "${user.home}/.local/share/multimc/", // linux, MultiMC
             "${user.home}/Library/Application Support/PrismLauncher/", // macOS, PrismLauncher

--- a/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
@@ -1,0 +1,150 @@
+package net.neoforged.neoform.runtime.cache;
+
+import net.neoforged.neoform.runtime.utils.AnsiColor;
+import net.neoforged.neoform.runtime.utils.Logger;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Searches for installation locations of the Minecraft launcher.
+ */
+public class LauncherInstallations {
+    private static final Logger LOG = Logger.create();
+
+    // Some are sourced from
+    // https://github.com/SpongePowered/VanillaGradle/blob/ccc45765d9881747b2c922be7a13c453c32ce9ed/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/Constants.java#L61-L71
+    private static final String[] CANDIDATES = {
+            "${env.APPDATA}/.minecraft/", // Windows, default launcher
+            "${user.home}/.minecraft/", // linux, default launcher
+            "${user.home}/Library/Application Support/minecraft/", // macOS, default launcher
+            "${user.home}/curseforge/minecraft/Install/", // Windows, Curseforge Client
+            "${user.home}/.local/share/PrismLauncher/", // linux, PrismLauncher
+            "${user.home}/.local/share/multimc/", // linux, MultiMC
+            "${user.home}/Library/Application Support/PrismLauncher/", // macOS, PrismLauncher
+            "${env.APPDATA}/PrismLauncher/", // Windows, PrismLauncher
+            "${user.home}/scoop/persist/multimc/", // Windows, MultiMC via Scoop
+    };
+
+    private final List<LauncherDirectory> launcherDirectories = new ArrayList<>();
+
+    // If true, the scan was already performed and launcherDirectories is up-to-date
+    private boolean scanned;
+
+    private boolean verbose;
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    /**
+     * @return The {@code libraries} directories of all Minecraft launcher installations that could be found.
+     */
+    public List<Path> getLibraryDirectories() {
+        scanIfNecessary();
+
+        var results = new ArrayList<Path>();
+        for (var launcherDirectory : launcherDirectories) {
+            var librariesDir = launcherDirectory.directory().resolve("libraries");
+            if (Files.isDirectory(librariesDir)) {
+                results.add(librariesDir);
+            }
+        }
+        return results;
+    }
+
+    private void scanIfNecessary() {
+        if (scanned) {
+            return;
+        }
+
+        // In CI, we can assume that the Minecraft launcher is not going to be installed.
+        // Skip scanning for it there.
+        // See: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+        // See: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+        if ("true".equals(System.getenv("CI"))) {
+            if (verbose) {
+                LOG.println("Not scanning for Minecraft Launcher installations in CI");
+            }
+            scanned = true;
+            return;
+        }
+
+        if (verbose) {
+            LOG.println("Scanning for Minecraft Launcher installations");
+        }
+
+        var replacementPattern = Pattern.compile("\\$\\{([^}]+)}");
+
+        for (var candidate : CANDIDATES) {
+            var matcher = replacementPattern.matcher(candidate);
+
+            var unmatchedVariables = new ArrayList<String>();
+            candidate = matcher.replaceAll(match -> {
+                var variable = match.group(1);
+                String value;
+                if (variable.startsWith("env.")) {
+                    value = System.getenv(variable.substring("env.".length()));
+                } else {
+                    value = System.getProperty(variable);
+                }
+
+                if (value == null) {
+                    unmatchedVariables.add(variable);
+                    return "";
+                }
+                return Matcher.quoteReplacement(value);
+            });
+            if (!unmatchedVariables.isEmpty()) {
+                if (verbose) {
+                    LOG.println("  Skipping candidate " + candidate + " due to undefined references: " + unmatchedVariables);
+                }
+                continue; // Ignoring due to unmatched variables
+            }
+
+            try {
+                var result = analyzeLauncherDirectory(candidate);
+                if (result != null) {
+                    launcherDirectories.add(result);
+                }
+            } catch (Exception e) {
+                if (verbose) {
+                    LOG.println(" Failed to scan candidate " + candidate + ": " + e);
+                }
+            }
+        }
+
+        if (verbose) {
+            LOG.println("Launcher directories found:");
+            for (var launcherDirectory : launcherDirectories) {
+                LOG.println(AnsiColor.MUTED + "  " + launcherDirectory.directory
+                            + AnsiColor.RESET);
+            }
+        }
+
+        scanned = true;
+    }
+
+    @Nullable
+    private LauncherDirectory analyzeLauncherDirectory(String candidate) {
+        var installDir = Paths.get(candidate);
+        if (!Files.isDirectory(installDir)) {
+            if (verbose) {
+                LOG.println(AnsiColor.MUTED + " Not found: " + candidate + AnsiColor.RESET);
+            }
+            return null;
+        }
+
+        return new LauncherDirectory(installDir);
+    }
+
+    private record LauncherDirectory(Path directory) {
+    }
+}

--- a/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
@@ -27,6 +27,7 @@ public class LauncherInstallations {
             "${user.home}/.minecraft/", // linux, default launcher
             "${user.home}/Library/Application Support/minecraft/", // macOS, default launcher
             "${user.home}/curseforge/minecraft/Install/", // Windows, Curseforge Client
+            "${env.APPDATA}/com.modrinth.theseus/meta/", // Windows, Modrinth App
             "${user.home}/.local/share/PrismLauncher/", // linux, PrismLauncher
             "${user.home}/.local/share/multimc/", // linux, MultiMC
             "${user.home}/Library/Application Support/PrismLauncher/", // macOS, PrismLauncher

--- a/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cache/LauncherInstallations.java
@@ -42,6 +42,15 @@ public class LauncherInstallations {
 
     private boolean verbose;
 
+    public LauncherInstallations(List<Path> additionalLauncherDirs) {
+        for (var dir : additionalLauncherDirs) {
+            var launcherDir = analyzeLauncherDirectory(dir);
+            if (launcherDir != null) {
+                launcherDirectories.add(launcherDir);
+            }
+        }
+    }
+
     public void setVerbose(boolean verbose) {
         this.verbose = verbose;
     }
@@ -85,13 +94,13 @@ public class LauncherInstallations {
             }
 
             try {
-                var result = analyzeLauncherDirectory(candidate);
+                var result = analyzeLauncherDirectory(Paths.get(candidate));
                 if (result != null) {
                     launcherDirectories.add(result);
                 }
             } catch (Exception e) {
                 if (verbose) {
-                    LOG.println(" Failed to scan candidate " + candidate + ": " + e);
+                    LOG.println(" Failed to scan launcher directory " + candidate + ": " + e);
                 }
             }
         }
@@ -135,11 +144,10 @@ public class LauncherInstallations {
     }
 
     @Nullable
-    private LauncherDirectory analyzeLauncherDirectory(String candidate) {
-        var installDir = Paths.get(candidate);
+    private LauncherDirectory analyzeLauncherDirectory(Path installDir) {
         if (!Files.isDirectory(installDir)) {
             if (verbose) {
-                LOG.println(AnsiColor.MUTED + " Not found: " + candidate + AnsiColor.RESET);
+                LOG.println(AnsiColor.MUTED + " Not found: " + installDir + AnsiColor.RESET);
             }
             return null;
         }

--- a/src/main/java/net/neoforged/neoform/runtime/cli/CacheMaintenance.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/CacheMaintenance.java
@@ -1,6 +1,5 @@
 package net.neoforged.neoform.runtime.cli;
 
-import net.neoforged.neoform.runtime.cache.CacheManager;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -12,9 +11,7 @@ public class CacheMaintenance implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        try (var cacheManager = new CacheManager(commonOptions.homeDir, commonOptions.getWorkDir())) {
-            cacheManager.setVerbose(commonOptions.verbose);
-
+        try (var cacheManager = commonOptions.createCacheManager()) {
             cacheManager.performMaintenance();
         }
 

--- a/src/main/java/net/neoforged/neoform/runtime/cli/CleanCacheCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/CleanCacheCommand.java
@@ -1,6 +1,5 @@
 package net.neoforged.neoform.runtime.cli;
 
-import net.neoforged.neoform.runtime.cache.CacheManager;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -12,9 +11,7 @@ public class CleanCacheCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        try (var cacheManager = new CacheManager(commonOptions.homeDir, commonOptions.getWorkDir())) {
-            cacheManager.setVerbose(commonOptions.verbose);
-
+        try (var cacheManager = commonOptions.createCacheManager()) {
             cacheManager.cleanUpAll();
         }
 

--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -28,7 +28,7 @@ public class Main {
     @Option(names = "--work-dir", scope = ScopeType.INHERIT, description = "Where temporary working directories are stored. Defaults to the subfolder 'work' in the NFRT home dir.")
     Path workDir;
 
-    @Option(names = "--repository", arity = "*", scope = ScopeType.INHERIT, description = "Overriddes Maven repositories used for downloading artifacts.")
+    @Option(names = "--repository", arity = "*", scope = ScopeType.INHERIT, description = "Overrides Maven repositories used for downloading artifacts.")
     List<URI> repositories = List.of(URI.create("https://maven.neoforged.net/releases/"), Path.of(System.getProperty("user.home"), ".m2", "repository").toUri());
 
     @Option(names = "--add-repository", arity = "*", scope = ScopeType.INHERIT, description = "Add Maven repositories for downloading artifacts.")
@@ -50,7 +50,7 @@ public class Main {
     boolean warnOnArtifactManifestMiss;
 
     @Option(names = "--launcher-meta-uri", scope = ScopeType.INHERIT)
-    URI launcherManifestUrl = URI.create("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json");
+URI launcherManifestUrl = URI.create("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json");
 
     @Option(
             names = "--verbose",

--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -34,6 +34,9 @@ public class Main {
     @Option(names = "--add-repository", arity = "*", scope = ScopeType.INHERIT, description = "Add Maven repositories for downloading artifacts.")
     List<URI> additionalRepositories = new ArrayList<>();
 
+    @Option(names = "--launcher-dir", arity = "*", scope = ScopeType.INHERIT, description = "Specifies one or more Minecraft launcher installation directories. NFRT will try to reuse files from these directories.")
+    List<Path> launcherDirs = new ArrayList<>();
+
     @Option(names = "--artifact-manifest", scope = ScopeType.INHERIT)
     Path artifactManifest;
 
@@ -130,7 +133,7 @@ public class Main {
     }
 
     public LauncherInstallations createLauncherInstallations() {
-        var installations = new LauncherInstallations();
+        var installations = new LauncherInstallations(launcherDirs);
         installations.setVerbose(verbose);
         return installations;
     }

--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -50,7 +50,7 @@ public class Main {
     boolean warnOnArtifactManifestMiss;
 
     @Option(names = "--launcher-meta-uri", scope = ScopeType.INHERIT)
-URI launcherManifestUrl = URI.create("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json");
+    URI launcherManifestUrl = URI.create("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json");
 
     @Option(
             names = "--verbose",

--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -6,6 +6,7 @@ import net.neoforged.neoform.runtime.cache.LauncherInstallations;
 import net.neoforged.neoform.runtime.downloads.DownloadManager;
 import net.neoforged.neoform.runtime.utils.Logger;
 import net.neoforged.neoform.runtime.utils.OsUtil;
+import org.jetbrains.annotations.Nullable;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ public class Main {
     Path homeDir = getDefaultHomeDir();
 
     @Option(names = "--work-dir", scope = ScopeType.INHERIT, description = "Where temporary working directories are stored. Defaults to the subfolder 'work' in the NFRT home dir.")
+    @Nullable
     Path workDir;
 
     @Option(names = "--repository", arity = "*", scope = ScopeType.INHERIT, description = "Overrides Maven repositories used for downloading artifacts.")
@@ -38,6 +40,7 @@ public class Main {
     List<Path> launcherDirs = new ArrayList<>();
 
     @Option(names = "--artifact-manifest", scope = ScopeType.INHERIT)
+    @Nullable
     Path artifactManifest;
 
     @Option(

--- a/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/Main.java
@@ -1,9 +1,14 @@
 package net.neoforged.neoform.runtime.cli;
 
+import net.neoforged.neoform.runtime.artifacts.ArtifactManager;
+import net.neoforged.neoform.runtime.cache.CacheManager;
+import net.neoforged.neoform.runtime.cache.LauncherInstallations;
+import net.neoforged.neoform.runtime.downloads.DownloadManager;
 import net.neoforged.neoform.runtime.utils.Logger;
 import net.neoforged.neoform.runtime.utils.OsUtil;
 import picocli.CommandLine;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -116,5 +121,44 @@ public class Main {
         var result = new ArrayList<>(repositories);
         result.addAll(additionalRepositories);
         return result;
+    }
+
+    public CacheManager createCacheManager() throws IOException {
+        var cacheManager = new CacheManager(homeDir, getWorkDir());
+        cacheManager.setVerbose(verbose);
+        return cacheManager;
+    }
+
+    public LauncherInstallations createLauncherInstallations() {
+        var installations = new LauncherInstallations();
+        installations.setVerbose(verbose);
+        return installations;
+    }
+
+    public LockManager createLockManager() throws IOException {
+        var lockManager = new LockManager(homeDir);
+        lockManager.setVerbose(verbose);
+        return lockManager;
+    }
+
+    public ArtifactManager createArtifactManager(CacheManager cacheManager,
+                                                 DownloadManager downloadManager,
+                                                 LockManager lockManager,
+                                                 LauncherInstallations launcherInstallations) throws IOException {
+        var artifactManager = new ArtifactManager(
+                getEffectiveRepositories(),
+                cacheManager,
+                downloadManager,
+                lockManager,
+                launcherManifestUrl,
+                launcherInstallations
+        );
+        artifactManager.setWarnOnArtifactManifestMiss(warnOnArtifactManifestMiss);
+
+        if (artifactManifest != null) {
+            artifactManager.loadArtifactManifest(artifactManifest);
+        }
+
+        return artifactManager;
     }
 }


### PR DESCRIPTION
Tries to find MC Launcher installations using a set of well known locations. This behavior is disabled in CI by default, by inspecting the relatively standard `CI` environment variable.

The asset manager will now use libraries found in launcher installations directly and not re-download or copy them.

This PR also refactors some of the shared service creation and moves it to the common argument class `Main` for easier reuse of individual services.