### PR TITLE
Fix the logic of running internal tools using the host JRE being inverted

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/actions/ExternalJavaToolAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/ExternalJavaToolAction.java
@@ -75,12 +75,12 @@ public class ExternalJavaToolAction implements ExecutionNodeAction {
 
         String javaExecutablePath;
         if (useHostJavaExecutable) {
-            javaExecutablePath = environment.getJavaExecutable();
-        } else {
             javaExecutablePath = ProcessHandle.current()
                     .info()
                     .command()
                     .orElseThrow();
+        } else {
+            javaExecutablePath = environment.getJavaExecutable();
         }
 
         var workingDir = environment.getWorkspace();


### PR DESCRIPTION
This works exactly opposite to what was intended.
Internal tools like JST/DiffPatch should run with NFRTs JRE, even if we're running MCP for Java 1.8, while the tools from that MCP config should run with Java 1.8. The toggle currently does the exact opposite of that.