### PR TITLE
Very Legacy (basic support for 1.16.5 and older)

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithJDK.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithJDK.java
@@ -40,7 +40,7 @@ public class RecompileSourcesActionWithJDK extends RecompileSourcesAction {
             try (var stream = Files.walk(sourceRoot).filter(Files::isRegularFile)) {
                 stream.forEach(path -> {
                     var filename = path.getFileName().toString();
-                    if (filename.endsWith(".java")) {
+                    if (filename.endsWith(".java") && !filename.equals("package-info-template.java")) {
                         sourcePaths.add(path);
                     } else {
                         nonSourcePaths.add(path);

--- a/src/main/java/net/neoforged/neoform/runtime/actions/RemapSrgSourcesWithMcpAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/RemapSrgSourcesWithMcpAction.java
@@ -1,0 +1,112 @@
+package net.neoforged.neoform.runtime.actions;
+
+import net.neoforged.neoform.runtime.cache.CacheKeyBuilder;
+import net.neoforged.neoform.runtime.engine.ProcessingEnvironment;
+import net.neoforged.neoform.runtime.graph.ExecutionNodeAction;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Takes a zip-file of Java sources and replaces SRG identifiers with
+ * identifiers from a mapping file.
+ * This version of {@link RemapSrgSourcesAction} uses MCP Mappings data for
+ * the intermediate->named mapping.
+ * The mappings are loaded from an MCP mappings ZIP, which contains CSV files with mappings for SRG->Named.
+ */
+public class RemapSrgSourcesWithMcpAction implements ExecutionNodeAction {
+    private static final Pattern SRG_FINDER = Pattern.compile("[fF]unc_\\d+_[a-zA-Z_]+|m_\\d+_|[fF]ield_\\d+_[a-zA-Z_]+|f_\\d+_");
+
+    private final Path mcpMappingsData;
+
+    public RemapSrgSourcesWithMcpAction(Path mcpMappingsData) {
+        this.mcpMappingsData = mcpMappingsData;
+    }
+
+    @Override
+    public void run(ProcessingEnvironment environment) throws IOException, InterruptedException {
+        var mappings = new HashMap<String, String>();
+
+        try (var zf = new ZipFile(mcpMappingsData.toFile())) {
+            loadMappingsCsv(zf, "fields.csv", mappings);
+            loadMappingsCsv(zf, "methods.csv", mappings);
+        }
+
+        var sourcesPath = environment.getRequiredInputPath("sources");
+        var outputPath = environment.getOutputPath("output");
+
+        try (var zipIn = new ZipInputStream(new BufferedInputStream(Files.newInputStream(sourcesPath)));
+             var zipOut = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(outputPath)))) {
+            for (var entry = zipIn.getNextEntry(); entry != null; entry = zipIn.getNextEntry()) {
+                zipOut.putNextEntry(entry);
+
+                if (entry.getName().endsWith(".java")) {
+                    var sourceCode = new String(zipIn.readAllBytes(), StandardCharsets.UTF_8);
+                    var mappedSource = mapSourceCode(sourceCode, mappings);
+                    zipOut.write(mappedSource.getBytes(StandardCharsets.UTF_8));
+                } else {
+                    zipIn.transferTo(zipOut);
+                }
+                zipOut.closeEntry();
+            }
+        }
+    }
+
+    // A very rudimentary parser for the CSV files inside the mappings ZIP.
+    // Ignores everything except the first two columns.
+    // Example:
+    // searge,name,side,desc
+    // field_100013_f,isPotionDurationMax,0,"True if potion effect duration is at maximum, false otherwise."
+    private void loadMappingsCsv(ZipFile zf, String filename, Map<String, String> mappings) throws IOException {
+        var entry = zf.getEntry(filename);
+        if (entry == null) {
+            throw new IllegalStateException("MCP mappings ZIP file is missing entry " + filename);
+        }
+
+        try (var reader = new BufferedReader(new InputStreamReader(zf.getInputStream(entry)))) {
+            var header = reader.readLine();
+            if (!header.startsWith("searge,name,")) {
+                throw new IOException("Invalid header for Mappings CSV: " + filename);
+            }
+            String line;
+            while ((line = reader.readLine()) != null) {
+                var parts = line.split(",", 3);
+                if (parts.length < 2) {
+                    continue;
+                }
+                String seargeName = parts[0];
+                String name = parts[1];
+                mappings.put(seargeName, name);
+            }
+        }
+    }
+
+    @Override
+    public void computeCacheKey(CacheKeyBuilder ck) {
+        ExecutionNodeAction.super.computeCacheKey(ck);
+        ck.addPath("mcp mappings data", mcpMappingsData);
+    }
+
+    private static String mapSourceCode(String sourceCode, Map<String, String> srgNamesToOfficial) {
+        var m = SRG_FINDER.matcher(sourceCode);
+        return m.replaceAll(matchResult -> {
+            var matched = matchResult.group();
+            // Some will be unmapped
+            var mapped = srgNamesToOfficial.getOrDefault(matched, matched);
+            return Matcher.quoteReplacement(mapped);
+        });
+    }
+}

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/ArtifactManager.java
@@ -126,10 +126,28 @@ public class ArtifactManager {
             return externalArtifact;
         }
 
+        // Yet another special case: dynamic versions!
+        // Used in 1.12.1, for example. And yes, this will be very slow.
+        if (mavenCoordinate.isDynamicVersion()) {
+            var availableVersions = MavenMetadata.gatherVersions(
+                    downloadManager,
+                    repositoryBaseUrls,
+                    mavenCoordinate.groupId(),
+                    mavenCoordinate.artifactId()
+            );
+            for (var availableVersion : availableVersions) {
+                if (mavenCoordinate.matchesVersion(availableVersion.version())) {
+                    var concreteMavenCoordinate = mavenCoordinate.withVersion(availableVersion.version());
+                    return get(concreteMavenCoordinate, availableVersion.repositoryUrl());
+                }
+            }
+        }
+
         var finalLocation = artifactsCache.resolve(mavenCoordinate.toRelativeRepositoryPath());
 
         // Special case: NeoForge reference libraries that are only available via the Mojang download server
-        if (mavenCoordinate.groupId().equals("com.mojang") && mavenCoordinate.artifactId().equals("logging")) {
+        if (mavenCoordinate.groupId().equals("com.mojang") && mavenCoordinate.artifactId().equals("logging")
+            || mavenCoordinate.groupId().equals("net.minecraft") && mavenCoordinate.artifactId().equals("launchwrapper")) {
             return get(mavenCoordinate, MINECRAFT_LIBRARIES_URI);
         }
 

--- a/src/main/java/net/neoforged/neoform/runtime/artifacts/MavenMetadata.java
+++ b/src/main/java/net/neoforged/neoform/runtime/artifacts/MavenMetadata.java
@@ -1,0 +1,87 @@
+package net.neoforged.neoform.runtime.artifacts;
+
+import net.neoforged.neoform.runtime.downloads.DownloadManager;
+import net.neoforged.neoform.runtime.utils.Logger;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+final class MavenMetadata {
+    private static final Logger LOG = Logger.create();
+
+    private MavenMetadata() {
+    }
+
+    static List<AvailableVersion> gatherVersions(DownloadManager downloadManager,
+                                                 List<URI> repositoryBaseUrls,
+                                                 String groupId,
+                                                 String artifactId) throws IOException {
+        var versions = new ArrayList<AvailableVersion>();
+        for (var repositoryBaseUrl : repositoryBaseUrls) {
+            versions.addAll(gatherVersions(downloadManager, repositoryBaseUrl, groupId, artifactId));
+        }
+        return versions;
+    }
+
+    static List<AvailableVersion> gatherVersions(DownloadManager downloadManager,
+                                                 URI repositoryBaseUrl,
+                                                 String groupId,
+                                                 String artifactId) throws IOException {
+        var metadataUri = repositoryBaseUrl.toString();
+        if (!metadataUri.endsWith("/")) {
+            metadataUri += "/";
+        }
+        metadataUri += groupId.replace('.', '/') + "/" + artifactId + "/maven-metadata.xml";
+
+        byte[] metadataContent;
+
+        var tempFile = Files.createTempFile("maven-metadata", ".xml");
+        try {
+            Files.deleteIfExists(tempFile); // The downloader should assume it does not exist yet
+            downloadManager.download(URI.create(metadataUri), tempFile);
+            metadataContent = Files.readAllBytes(tempFile);
+        } catch (FileNotFoundException fnf) {
+            return List.of(); // Repository doesn't have artifact
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+
+        try (var in = new ByteArrayInputStream(metadataContent)) {
+            var result = new ArrayList<AvailableVersion>();
+            var documentBuilder = DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder();
+            var document = documentBuilder.parse(in).getDocumentElement();
+            var nodes = document.getChildNodes();
+            for (var i = 0; i < nodes.getLength(); i++) {
+                if (nodes.item(i) instanceof Element versioningEl && "versioning".equals(versioningEl.getTagName())) {
+                    for (var versions = versioningEl.getFirstChild(); versions != null; versions = versions.getNextSibling()) {
+                        if (versions instanceof Element versionsEl && "versions".equals(versionsEl.getTagName())) {
+                            for (var child = versionsEl.getFirstChild(); child != null; child = child.getNextSibling()) {
+                                if (child instanceof Element childEl && "version".equals(childEl.getTagName())) {
+                                    result.add(new AvailableVersion(
+                                            repositoryBaseUrl,
+                                            childEl.getTextContent().trim()
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            LOG.println("Failed to parse Maven metadata from " + metadataUri + ": " + e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    record AvailableVersion(URI repositoryUrl, String version) {
+    }
+
+}

--- a/src/main/java/net/neoforged/neoform/runtime/config/neoforge/NeoForgeConfig.java
+++ b/src/main/java/net/neoforged/neoform/runtime/config/neoforge/NeoForgeConfig.java
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
+import net.neoforged.neoform.runtime.config.neoform.NeoFormFunction;
 import net.neoforged.neoform.runtime.utils.FilenameUtil;
 import net.neoforged.neoform.runtime.utils.MavenCoordinate;
 import org.jetbrains.annotations.Nullable;
@@ -27,7 +28,9 @@ public record NeoForgeConfig(
         @SerializedName("patchesModifiedPrefix") @Nullable String modifiedPathPrefix,
         Map<String, JsonObject> runs,
         List<MavenCoordinate> libraries,
-        List<String> modules
+        List<String> modules,
+        // This was used in older MC versions (i.e. 1.12.2)
+        @SerializedName("processor") @Nullable NeoFormFunction sourcePreProcessor
 ) {
     public static NeoForgeConfig from(ZipFile zipFile) throws IOException {
         byte[] configContent;

--- a/src/main/java/net/neoforged/neoform/runtime/config/neoform/NeoFormConfig.java
+++ b/src/main/java/net/neoforged/neoform/runtime/config/neoform/NeoFormConfig.java
@@ -24,6 +24,12 @@ public record NeoFormConfig(int spec,
                             Map<String, NeoFormFunction> functions,
                             Map<String, List<MavenCoordinate>> libraries) {
 
+    public NeoFormConfig {
+        if (javaVersion == 0) {
+            javaVersion = 8; // Old versions didn't specify, but require Java 8
+        }
+    }
+
     public NeoFormDistConfig getDistConfig(String dist) {
         if (!steps.containsKey(dist)) {
             throw new IllegalArgumentException("This configuration does not include the distribution "

--- a/src/main/java/net/neoforged/neoform/runtime/engine/ProcessGeneration.java
+++ b/src/main/java/net/neoforged/neoform/runtime/engine/ProcessGeneration.java
@@ -59,9 +59,11 @@ public class ProcessGeneration {
     private boolean sourcesUseIntermediaryNames;
 
     /**
-     * For (Neo)Forge 1.20.1 and below, we have to remap method and field names from
-     * SRG to official names for development.
+     * For Pre-1.17, we were not using official mappings and require an external source
+     * for the mapping from intermediate to named. This was done using "MCP Mappings".
+     * This field can only be true if sourcesUseIntermediaryNames is also true.
      */
+    private boolean needsMcpMappingData;
 
     static ProcessGeneration fromMinecraftVersion(String minecraftVersion) {
         var releaseVersion = MinecraftReleaseVersion.parse(minecraftVersion);
@@ -88,6 +90,9 @@ public class ProcessGeneration {
         // In 1.20.2 and later, NeoForge switched to Mojmap at runtime and sources defined in Mojmap
         result.sourcesUseIntermediaryNames = isLessThanOrEqualTo(releaseVersion, MC_1_20_1);
 
+        // In 1.17.1 and later, Forge started using official Mojang mappings
+        result.needsMcpMappingData = isLessThanOrEqualTo(releaseVersion, MC_1_17_1);
+
         return result;
     }
 
@@ -103,6 +108,13 @@ public class ProcessGeneration {
      */
     public boolean sourcesUseIntermediaryNames() {
         return sourcesUseIntermediaryNames;
+    }
+
+    /**
+     * Do we support and need MCP mappings data to get readable names in source?
+     */
+    public boolean needsMcpMappingData() {
+        return needsMcpMappingData;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoform/runtime/graph/ExecutionNodeBuilder.java
+++ b/src/main/java/net/neoforged/neoform/runtime/graph/ExecutionNodeBuilder.java
@@ -16,6 +16,10 @@ public class ExecutionNodeBuilder {
         this.id = Objects.requireNonNull(id, "id");
     }
 
+    public String id() {
+        return id;
+    }
+
     public boolean hasInput(String inputId) {
         return nodeInputs.containsKey(inputId);
     }

--- a/src/main/java/net/neoforged/neoform/runtime/utils/MavenCoordinate.java
+++ b/src/main/java/net/neoforged/neoform/runtime/utils/MavenCoordinate.java
@@ -128,4 +128,29 @@ public record MavenCoordinate(String groupId, String artifactId, String extensio
                 version
         );
     }
+
+    public MavenCoordinate withVersion(String version) {
+        return new MavenCoordinate(
+                groupId,
+                artifactId,
+                extension,
+                classifier,
+                version
+        );
+    }
+
+    public boolean isDynamicVersion() {
+        // We only support extremely simple cases right now.
+        return version.endsWith("+");
+    }
+
+    public boolean matchesVersion(String version) {
+        // "+" acts as a prefix match according to Gradle
+        // https://docs.gradle.org/current/userguide/dependency_versions.html#sec:single-version-declarations
+        if (this.version.endsWith("+")) {
+            return version.startsWith(this.version.substring(0, this.version.length() - 1));
+        } else {
+            return this.version.equals(version);
+        }
+    }
 }


### PR DESCRIPTION
- Add rudimentary support for dynamic versions based on pulling in maven-metadata.xml, since older Forge versions used to reference some tooling via dynamic versions.
- Add support for specifying MCP mapping data files via CLI for 1.16.5 and older
- Add support for remapping sources based on those MCP mapping files instead of merged official mappings
- Automatically skip injecting `package-info-template.java` found in older Forge versions, since it doesn't compile