### PR TITLE
Add information to the maven pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import net.neoforged.gradleutils.PomUtilsExtension
+
 plugins {
     id 'java'
     id 'maven-publish'
@@ -130,6 +132,13 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+            pom {
+                name = 'NeoFormRuntime'
+                description = 'Standalone CLI tool to create artifacts used to compile mods against Minecraft'
+                pomUtils.githubRepo(it, 'NeoFormRuntime')
+                pomUtils.neoForgedDeveloper(it)
+                pomUtils.license(it, PomUtilsExtension.License.LGPL_v2)
+            }
         }
     }
 


### PR DESCRIPTION
This is usually useless but renovate can link to the repo when it detects the source url in the pom so it's useful to quickly navigate to the project and look at the commit history when bumping NFRT via renovate.