### PR TITLE
Add support to set the asset root used for asset downloads explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,15 @@ assets_root=...path to assets...
 While it may seem odd that NFRT supports passing NeoForm or NeoForge versions to this command, this is in service
 of potential Gradle plugins never having to actually read and parse the NeoForm configuration file.
 
-| Option                         | Description                                                                                                                                                                      |
-|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--asets-dir`                  | Where to store the downloaded assets. Optional. Defaults to `<nfrt_home>/assets`, or a detected Launcher installation.                                                           |
-| `--no-copy-launcher-assets`    | Disables copying of local Minecraft Launcher assets, if using the asset root directly is disabled.                                                                               |
-| `--no-use-launcher-asset-root` | Disables using a detected Minecraft Launcher installation directly to store the required assets.                                                                                 |
-| `--concurrent-downloads`       | Limits the maximum number of concurrent downloads. Default is 25.                                                                                                                |
-| `--write-properties`           | Writes a property file to the given path that contains the asset index id (`asset_index`) and asset root path (`assets_root`) suitable for passing to Minecraft.                 |
-| `--write-json`                 | Writes a JSON file to the given path that contains the asset index id (`asset_index`) and asset root path (`assets`) suitable for passing to Minecraft via a Neoform entrypoint. |
+| Option                         | Description                                                                                                                                                                       |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--asset-root`                 | Where to store the downloaded assets. Optional. Defaults to `<nfrt_home>/assets`, or a detected Launcher installation. Can also be set by environment variable `NFRT_ASSET_ROOT`. |
+| `--asset-repository`           | The remote URL to download assets from. Optional. Defaults to https://resources.download.minecraft.net. Can also be set by environment variable `NFRT_ASSET_REPOSITORY`.          |
+| `--no-copy-launcher-assets`    | Disables copying of local Minecraft Launcher assets, if using the asset root directly is disabled.                                                                                |
+| `--no-use-launcher-asset-root` | Disables using a detected Minecraft Launcher installation directly to store the required assets.                                                                                  |
+| `--concurrent-downloads`       | Limits the maximum number of concurrent downloads. Default is 25.                                                                                                                 |
+| `--write-properties`           | Writes a property file to the given path that contains the asset index id (`asset_index`) and asset root path (`assets_root`) suitable for passing to Minecraft.                  |
+| `--write-json`                 | Writes a JSON file to the given path that contains the asset index id (`asset_index`) and asset root path (`assets`) suitable for passing to Minecraft via a Neoform entrypoint.  |
 
 ## Common Options
 

--- a/src/main/java/net/neoforged/neoform/runtime/cli/DownloadAssetsCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/DownloadAssetsCommand.java
@@ -28,7 +28,12 @@ public class DownloadAssetsCommand implements Callable<Integer> {
     @CommandLine.ArgGroup(multiplicity = "1")
     public Version version;
 
-    @CommandLine.Option(names = "--asset-repository")
+    // Support overriding the asset root via an environment property, which is aimed at CI/CD using separate
+    // cross-version caches for this.
+    @CommandLine.Option(names = "--asset-root", defaultValue = "${env:NFRT_ASSET_ROOT}")
+    public Path assetRoot;
+
+    @CommandLine.Option(names = "--asset-repository", defaultValue = "${env:NFRT_ASSET_REPOSITORY}")
     public URI assetRepository = URI.create("https://resources.download.minecraft.net/");
 
     @CommandLine.Option(
@@ -84,7 +89,7 @@ public class DownloadAssetsCommand implements Callable<Integer> {
 
             var minecraftVersion = getMinecraftVersion(artifactManager);
 
-            var downloader = new AssetDownloader(downloadManager, artifactManager, launcherInstallations, cacheManager);
+            var downloader = new AssetDownloader(downloadManager, artifactManager, launcherInstallations, cacheManager, assetRoot);
             AssetDownloadResult result;
             try {
                 result = downloader.downloadAssets(

--- a/src/main/java/net/neoforged/neoform/runtime/downloads/AssetDownloader.java
+++ b/src/main/java/net/neoforged/neoform/runtime/downloads/AssetDownloader.java
@@ -43,15 +43,19 @@ public class AssetDownloader {
     private final ArtifactManager artifactManager;
     private final LauncherInstallations launcherInstallations;
     private final CacheManager cacheManager;
+    @Nullable
+    private final Path fixedAssetRoot;
 
     public AssetDownloader(DownloadManager downloadManager,
                            ArtifactManager artifactManager,
                            LauncherInstallations launcherInstallations,
-                           CacheManager cacheManager) {
+                           CacheManager cacheManager,
+                           @Nullable Path fixedAssetRoot) {
         this.downloadManager = downloadManager;
         this.artifactManager = artifactManager;
         this.launcherInstallations = launcherInstallations;
         this.cacheManager = cacheManager;
+        this.fixedAssetRoot = fixedAssetRoot;
     }
 
     public AssetDownloadResult downloadAssets(String minecraftVersion,
@@ -107,6 +111,11 @@ public class AssetDownloader {
     }
 
     private Path selectAssetRoot(boolean useLauncherAssetRoot, AssetIndexReference assetIndexReference) {
+        if (fixedAssetRoot != null) {
+            LOG.println("Using fixed asset root: " + fixedAssetRoot);
+            return fixedAssetRoot;
+        }
+
         Path assetRoot = null;
         if (useLauncherAssetRoot) {
             // We already may have an asset root with specifically the index we're looking for,


### PR DESCRIPTION
The use cases I see:

- Setting `NFRT_ASSET_ROOT` via Github Action to use a cache directory that is cross-branch, since the MC assets do not change that much from version to version.
- Setting `NFRT_ASSET_REPOSITORY` for people that want to use a local proxy (we might also use a pull-through HTTP proxy for assets).