### PR TITLE
Fix automated cleanup of lock files.

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/cli/NeoFormEngineCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/NeoFormEngineCommand.java
@@ -71,6 +71,7 @@ public abstract class NeoFormEngineCommand implements Callable<Integer> {
 
             if (!disableCacheMaintenance) {
                 cacheManager.performMaintenance();
+                lockManager.performMaintenance();
             }
 
             var artifactManager = commonOptions.createArtifactManager(cacheManager, downloadManager, lockManager, launcherInstallations);


### PR DESCRIPTION
The explicit `cache-maintenance` command does clean up, but we forgot to auto-cleanup locks too when other commands run.