### PR TITLE
Experiment with only recompiling changed classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,11 @@ idea {
                     programParameters = "run --dist joined --neoforge net.neoforged:neoforge:21.0.0-beta:userdev --write-result=compiled:build/minecraft.jar --write-result=clientResources:build/client-extra.jar --write-result=sources:build/minecraft-sources.jar"
                     moduleRef(project, sourceSets.main)
                 }
+                "Experiments"(Application) {
+                    mainClass = mainClassName
+                    programParameters = "run --verbose --dist joined --neoforge net.neoforged:neoforge:21.0.0-beta:userdev --interface-injection-data=interfaces_test.json --validated-access-transformer=test_at.cfg --write-result=node.injectModifiedClasses.output.output:build/injectModifiedClasses-output.jar"
+                    moduleRef(project, sourceSets.main)
+                }
                 "Run Neoform 1.21 (joined)"(Application) {
                     mainClass = mainClassName
                     programParameters = "run --dist joined --neoform net.neoforged:neoform:1.21-20240613.152323@zip --write-result=compiled:build/minecraft.jar --write-result=clientResources:build/client-extra.jar --write-result=sources:build/minecraft-sources.jar"

--- a/interfaces_test.json
+++ b/interfaces_test.json
@@ -1,0 +1,5 @@
+{
+  "net/minecraft/world/item/Item": [
+    "testproject/FunExtensions"
+  ]
+}

--- a/src/main/java/net/neoforged/neoform/runtime/actions/ApplySourceTransformAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/ApplySourceTransformAction.java
@@ -91,7 +91,7 @@ public class ApplySourceTransformAction extends ExternalJavaToolAction {
                 "--out-format", "ARCHIVE"
         );
 
-        if (!accessTransformersData.isEmpty() || !additionalAccessTransformers.isEmpty()) {
+        if (!accessTransformersData.isEmpty() || !additionalAccessTransformers.isEmpty() || !validatedAccessTransformers.isEmpty()) {
             args.add("--enable-accesstransformers");
 
             for (var dataId : accessTransformersData) {
@@ -107,7 +107,7 @@ public class ApplySourceTransformAction extends ExternalJavaToolAction {
 
             for (var path : validatedAccessTransformers) {
                 args.add("--access-transformer");
-                args.add(environment.getPathArgument(path));
+                args.add(environment.getPathArgument(path.toAbsolutePath())); // TODO: uniformize with the other calls in this class
             }
 
             for (var path : additionalAccessTransformers) {

--- a/src/main/java/net/neoforged/neoform/runtime/actions/MergeZipsAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/MergeZipsAction.java
@@ -1,0 +1,42 @@
+package net.neoforged.neoform.runtime.actions;
+
+import net.neoforged.neoform.runtime.engine.ProcessingEnvironment;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.zip.ZipException;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+// TODO: would be good to "merge" with MergeWithSourcesAction?
+public class MergeZipsAction extends BuiltInAction {
+    @Override
+    public void run(ProcessingEnvironment environment) throws IOException, InterruptedException {
+        var classesFile = environment.getRequiredInputPath("classes");
+        var extraClassesFile = environment.getRequiredInputPath("classes2");
+        var output = environment.getOutputPath("output");
+
+        try (var os = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(output)))) {
+
+            boolean first = true;
+            for (var sourceZip : List.of(classesFile, extraClassesFile)) {
+                try (var in = new ZipInputStream(new BufferedInputStream(Files.newInputStream(sourceZip)))) {
+                    for (var entry = in.getNextEntry(); entry != null; entry = in.getNextEntry()) {
+                        if (!first && entry.isDirectory()) {
+                            // Skip directories in case they would be duplicated
+                            // TODO: a bit crude
+                            continue;
+                        }
+                        os.putNextEntry(entry);
+                        in.transferTo(os);
+                        os.closeEntry();
+                    }
+                }
+                first = false;
+            }
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesAction.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 public abstract class RecompileSourcesAction extends BuiltInAction implements ExecutionNodeAction {
 
-    private final ExtensibleClasspath classpath = new ExtensibleClasspath();
-    private final ExtensibleClasspath sourcepath = new ExtensibleClasspath();
+    private ExtensibleClasspath classpath = new ExtensibleClasspath();
+    private ExtensibleClasspath sourcepath = new ExtensibleClasspath();
     private int targetJavaVersion = 21;
 
     @Override
@@ -53,8 +53,16 @@ public abstract class RecompileSourcesAction extends BuiltInAction implements Ex
         return classpath;
     }
 
+    public void setClasspath(ExtensibleClasspath classpath) {
+        this.classpath = classpath;
+    }
+
     public ExtensibleClasspath getSourcepath() {
         return sourcepath;
+    }
+
+    public void setSourcepath(ExtensibleClasspath sourcepath) {
+        this.sourcepath = sourcepath;
     }
 
     public int getTargetJavaVersion() {
@@ -64,4 +72,6 @@ public abstract class RecompileSourcesAction extends BuiltInAction implements Ex
     public void setTargetJavaVersion(int targetJavaVersion) {
         this.targetJavaVersion = targetJavaVersion;
     }
+
+    public abstract RecompileSourcesAction copy();
 }

--- a/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithECJ.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithECJ.java
@@ -212,6 +212,15 @@ public class RecompileSourcesActionWithECJ extends RecompileSourcesAction {
         ck.add("compiler type", "eclipse");
     }
 
+    @Override
+    public RecompileSourcesAction copy() {
+        var ret = new RecompileSourcesActionWithECJ();
+        ret.setClasspath(getClasspath().copy());
+        ret.setSourcepath(getSourcepath().copy());
+        ret.setTargetJavaVersion(getTargetJavaVersion());
+        return ret;
+    }
+
     static class ECJFilesystem extends FileSystem {
         protected ECJFilesystem(Classpath[] paths, String[] initialFileNames, boolean annotationsFromClasspath) {
             super(paths, initialFileNames, annotationsFromClasspath);

--- a/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithJDK.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/RecompileSourcesActionWithJDK.java
@@ -108,4 +108,13 @@ public class RecompileSourcesActionWithJDK extends RecompileSourcesAction {
                 "-implicit:none" // Prevents source files from the source-path from being emitted
         );
     }
+
+    @Override
+    public RecompileSourcesAction copy() {
+        var ret = new RecompileSourcesActionWithJDK();
+        ret.setClasspath(getClasspath().copy());
+        ret.setSourcepath(getSourcepath().copy());
+        ret.setTargetJavaVersion(getTargetJavaVersion());
+        return ret;
+    }
 }

--- a/src/main/java/net/neoforged/neoform/runtime/actions/SelectSourcesToRecompile.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/SelectSourcesToRecompile.java
@@ -1,0 +1,105 @@
+package net.neoforged.neoform.runtime.actions;
+
+import net.neoforged.neoform.runtime.engine.ProcessingEnvironment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+public class SelectSourcesToRecompile extends BuiltInAction {
+    @Override
+    public void run(ProcessingEnvironment environment) throws IOException, InterruptedException {
+        var originalSources = environment.getRequiredInputPath("originalSources");
+        var originalClasses = environment.getRequiredInputPath("originalClasses");
+        var transformedSources = environment.getRequiredInputPath("transformedSources");
+
+        var unchangedClasses = environment.getOutputPath("unchangedClasses");
+        var changedSourcesOnly = environment.getOutputPath("changedSourcesOnly");
+
+        // Read all original sources to memory
+        var originalSourcesContents = new HashMap<String, byte[]>();
+        try (var zf = new ZipFile(originalSources.toFile())) {
+            var entries = zf.entries();
+            while (entries.hasMoreElements()) {
+                var entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                try (var is = zf.getInputStream(entry)) {
+                    originalSourcesContents.put(entry.getName(), is.readAllBytes());
+                }
+            }
+        }
+
+        // Copy unchanged sources to the output
+        var changedSourcePaths = new HashSet<String>();
+        try (var os = Files.newOutputStream(changedSourcesOnly);
+             var zos = new ZipOutputStream(os)) {
+
+            try (var transformedZip = new ZipFile(transformedSources.toFile())) {
+                var entries = transformedZip.entries();
+                while (entries.hasMoreElements()) {
+                    var entry = entries.nextElement();
+                    if (entry.isDirectory()) {
+                        continue;
+                    }
+
+                    try (var is = transformedZip.getInputStream(entry)) {
+                        var data = is.readAllBytes();
+
+                        if (!Arrays.equals(data, originalSourcesContents.get(entry.getName()))) {
+                            changedSourcePaths.add(entry.getName());
+                            // Copy to output
+                            var copiedEntry = new ZipEntry(entry.getName());
+                            copiedEntry.setMethod(entry.getMethod());
+                            zos.putNextEntry(copiedEntry);
+                            zos.write(data);
+                            zos.closeEntry();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Copy unchanged classes
+        try (var os = Files.newOutputStream(unchangedClasses);
+             var zos = new ZipOutputStream(os)) {
+
+            try (var originalZip = new ZipFile(originalClasses.toFile())) {
+                var entries = originalZip.entries();
+                while (entries.hasMoreElements()) {
+                    var entry = entries.nextElement();
+                    if (!entry.isDirectory()) {
+                        // Remove trailing .class
+                        var sourceName = entry.getName();
+                        if (sourceName.endsWith(".class")) {
+                            sourceName = sourceName.substring(0, sourceName.length() - 6);
+                        }
+                        // Remove inner class suffix
+                        sourceName = sourceName.split("\\$")[0];
+                        // Add trailing .java
+                        sourceName += ".java";
+
+                        if (changedSourcePaths.contains(sourceName)) {
+                            // Skip this entry
+                            continue;
+                        }
+                    }
+
+                    try (var is = originalZip.getInputStream(entry)) {
+                        // Copy to output
+                        var copiedEntry = new ZipEntry(entry.getName());
+                        zos.putNextEntry(copiedEntry);
+                        is.transferTo(zos);
+                        zos.closeEntry();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
@@ -5,8 +5,10 @@ import net.neoforged.neoform.runtime.actions.ExternalJavaToolAction;
 import net.neoforged.neoform.runtime.actions.InjectFromZipFileSource;
 import net.neoforged.neoform.runtime.actions.InjectZipContentAction;
 import net.neoforged.neoform.runtime.actions.MergeWithSourcesAction;
+import net.neoforged.neoform.runtime.actions.MergeZipsAction;
 import net.neoforged.neoform.runtime.actions.PatchActionFactory;
 import net.neoforged.neoform.runtime.actions.RecompileSourcesAction;
+import net.neoforged.neoform.runtime.actions.SelectSourcesToRecompile;
 import net.neoforged.neoform.runtime.actions.StripManifestDigestContentFilter;
 import net.neoforged.neoform.runtime.artifacts.ClasspathItem;
 import net.neoforged.neoform.runtime.config.neoforge.NeoForgeConfig;
@@ -217,8 +219,6 @@ public class RunNeoFormCommand extends NeoFormEngineCommand {
             engine.loadNeoFormData(neoFormDataPath, dist);
         }
 
-        applyAdditionalAccessTransformers(engine);
-
         if (parchmentData != null) {
             var parchmentDataFile = artifactManager.get(parchmentData);
             Consumer<ApplySourceTransformAction> jstConsumer = transformSources -> {
@@ -236,35 +236,86 @@ public class RunNeoFormCommand extends NeoFormEngineCommand {
             }
         }
 
-        if (!interfaceInjectionDataFiles.isEmpty()) {
-            var transformNode = getOrAddTransformSourcesNode(engine);
-            ((ApplySourceTransformAction) transformNode.action()).setInjectedInterfaces(interfaceInjectionDataFiles);
-
-            // Add the stub source jar to the recomp classpath
-            engine.applyTransform(new ModifyAction<>(
-                    "recompile",
-                    RecompileSourcesAction.class,
-                    action -> {
-                        action.getSourcepath().add(ClasspathItem.of(transformNode.getRequiredOutput("stubs")));
-                    }
-            ));
-        }
+        applyAdditionalTransforms(engine);
 
         execute(engine);
     }
 
     /**
-     * Configure the engine to apply additional user-supplied access transformers to the game sources.
+     * Configure the engine to apply additional user-supplied access transformers and interfaces to the game sources.
+     * This is done by re-transforming the sources a second time, and only recompiling changed sources.
      */
-    private void applyAdditionalAccessTransformers(NeoFormEngine engine) {
+    private void applyAdditionalTransforms(NeoFormEngine engine) {
+        if (additionalAccessTransformers.isEmpty() && validatedAccessTransformers.isEmpty() && interfaceInjectionDataFiles.isEmpty()) {
+            return;
+        }
+
+        var graph = engine.getGraph();
+
+        // TODO: what if there is no transformSources node yet?
+        var applyAdditionalTransformsBuilder = graph.nodeBuilder("applyAdditionalTransforms");
+        sourceTransform(action -> {})
+                .make(applyAdditionalTransformsBuilder, graph.getRequiredOutput("transformSources", "output"));
+        var applyAdditionalTransforms = applyAdditionalTransformsBuilder.build();
+        // TODO: ugly
+        var sourceTransformAction = (ApplySourceTransformAction) applyAdditionalTransforms.action();
+
+        new ReplaceNodeOutput(
+                "recompile",
+                "output",
+                (engine_, recompileOutput) -> {
+                    var selectSourcesBuilder = graph.nodeBuilder("selectSourcesToRecompile");
+                    selectSourcesBuilder.inputFromNodeOutput("originalSources", "transformSources", "output");
+                    selectSourcesBuilder.input("originalClasses", recompileOutput.asInput());
+                    selectSourcesBuilder.input("transformedSources", applyAdditionalTransforms.getRequiredOutput("output").asInput());
+                    var unchangedClasses = selectSourcesBuilder.output("unchangedClasses", NodeOutputType.JAR, "Classes that were already compiled and whose corresponding sources did not change.");
+                    var changedSourcesOnly = selectSourcesBuilder.output("changedSourcesOnly", NodeOutputType.JAR, "Sources that were changed and need to be recompiled.");
+                    selectSourcesBuilder.action(new SelectSourcesToRecompile());
+                    var selectSources = selectSourcesBuilder.build();
+
+                    var recompileModifiedSources = graph.nodeBuilder("recompileModifiedSources");
+                    recompileModifiedSources.input("sources", changedSourcesOnly.asInput());
+                    recompileModifiedSources.input("versionManifest", recompileOutput.getNode().getRequiredInput("versionManifest"));
+                    var modifiedClasses = recompileModifiedSources.output("output", NodeOutputType.JAR, "Compiled minecraft sources that were changed.");
+
+                    var recompileAction = (RecompileSourcesAction) recompileOutput.getNode().action();
+                    // TODO: we need to ensure that the original classpath is not modified after this
+                    RecompileSourcesAction recompileModifiedAction = recompileAction.copy();
+                    recompileModifiedAction.getClasspath().add(ClasspathItem.of(unchangedClasses));
+                    recompileModifiedSources.action(recompileModifiedAction);
+                    recompileModifiedSources.build();
+
+                    var injectBuilder = graph.nodeBuilder("injectModifiedClasses");
+                    injectBuilder.input("classes", unchangedClasses.asInput());
+                    injectBuilder.input("classes2", modifiedClasses.asInput());
+                    var output = injectBuilder.output("output", NodeOutputType.JAR, "Compiled Minecraft sources with additional changes merged in.");
+                    injectBuilder.action(new MergeZipsAction());
+                    injectBuilder.build();
+
+                    return new ReplaceNodeOutput.ReplacementResult(output, List.of(selectSources));
+                })
+                .apply(engine, graph);
+
         if (!additionalAccessTransformers.isEmpty() || !validatedAccessTransformers.isEmpty()) {
-            var transformSources = getOrAddTransformSourcesAction(engine);
-            transformSources.setAdditionalAccessTransformers(additionalAccessTransformers.stream().map(Paths::get).toList());
-            transformSources.setValidatedAccessTransformers(validatedAccessTransformers.stream().map(Paths::get).toList());
+            sourceTransformAction.setAdditionalAccessTransformers(additionalAccessTransformers.stream().map(Paths::get).toList());
+            sourceTransformAction.setValidatedAccessTransformers(validatedAccessTransformers.stream().map(Paths::get).toList());
 
             if (validateAccessTransformers) {
-                transformSources.addArg("--access-transformer-validation=error");
+                sourceTransformAction.addArg("--access-transformer-validation=error");
             }
+        }
+
+        if (!interfaceInjectionDataFiles.isEmpty()) {
+            sourceTransformAction.setInjectedInterfaces(interfaceInjectionDataFiles);
+
+            // Add the stub source jar to the recomp classpath
+            engine.applyTransform(new ModifyAction<>(
+                    "recompileModifiedSources",
+                    RecompileSourcesAction.class,
+                    action -> {
+                        action.getSourcepath().add(ClasspathItem.of(applyAdditionalTransforms.getRequiredOutput("stubs")));
+                    }
+            ));
         }
     }
 

--- a/test_at.cfg
+++ b/test_at.cfg
@@ -1,0 +1,35 @@
+# Used for GUI rendering
+protected net.minecraft.client.gui.components.Tooltip <init>(Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;)V
+public-f net.minecraft.client.gui.components.AbstractWidget render(Lnet/minecraft/client/gui/GuiGraphics;IIF)V
+
+# Used for menu interactions
+public net.minecraft.world.inventory.AbstractContainerMenu createCarriedSlotAccess()Lnet/minecraft/world/entity/SlotAccess;
+
+# Used for block state properties
+public net.minecraft.world.level.block.Blocks never(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Z
+
+# Used for ore registration
+public net.minecraft.data.worldgen.placement.OrePlacements commonOrePlacement(ILnet/minecraft/world/level/levelgen/placement/PlacementModifier;)Ljava/util/List;
+
+# Used to render pipe highlight
+public net.minecraft.client.renderer.LevelRenderer renderShape(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/world/phys/shapes/VoxelShape;DDDFFFF)V
+
+# Used to access all chunks
+public net.minecraft.server.level.ChunkMap updatingChunkMap
+
+# Used for datagen
+public-f net.minecraft.data.recipes.RecipeProvider getName()Ljava/lang/String;
+# To convert shaped recipes to machine recipes
+public net.minecraft.world.item.crafting.ShapedRecipe pattern
+public net.minecraft.world.item.crafting.ShapedRecipe result
+public net.minecraft.world.item.crafting.ShapedRecipePattern data
+
+# Used to register villager trades
+public net.minecraft.world.entity.npc.VillagerTrades$EmeraldForItems
+public net.minecraft.world.entity.npc.VillagerTrades$ItemsForEmeralds
+
+# Used for jetpack
+public net.minecraft.server.network.ServerGamePacketListenerImpl aboveGroundTickCount
+
+# Used to delay attacks after a barrel interaction
+public net.minecraft.client.multiplayer.MultiPlayerGameMode destroyDelay


### PR DESCRIPTION
I have no idea if it's correct yet, but it's reasonably fast. Not as fast as I would have liked though.

With this PR, a change to the ATs takes about 20s to apply on my machine:
- 6s in `applyAdditionalTransforms`, the second JST application.
- 6s in `selectSourcesToRecompile`, which diffs the zips. This seems crazy slow. :/
- 4.5s in `recompileModifiedSources`, the recompilation of only the changed sources.
- 2s in `injectModifiedClasses`, merging the newly compiled classes with the old unchanged ones.

**To benchmark on your machine, just change the `test_at.cfg` file by (un)commenting one line, and then run again the `Experiments` run.**

It should be possible to optimize the running time even further?