### PR TITLE
Fix Minecraft version parsing logic

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/engine/ProcessGeneration.java
+++ b/src/main/java/net/neoforged/neoform/runtime/engine/ProcessGeneration.java
@@ -20,7 +20,7 @@ public class ProcessGeneration {
                 .thenComparingInt(MinecraftReleaseVersion::minor)
                 .thenComparingInt(MinecraftReleaseVersion::patch);
 
-        private static final Pattern RELEASE_VERSION = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)$");
+        private static final Pattern RELEASE_VERSION = Pattern.compile("^(\\d+)\\.(\\d+)(?:\\.(\\d+))?$");
 
         @Nullable
         public static MinecraftReleaseVersion parse(String version) {
@@ -29,7 +29,7 @@ public class ProcessGeneration {
                 return new MinecraftReleaseVersion(
                         Integer.parseUnsignedInt(m.group(1)),
                         Integer.parseUnsignedInt(m.group(2)),
-                        Integer.parseUnsignedInt(m.group(3))
+                        m.group(3) != null ? Integer.parseUnsignedInt(m.group(3)) : 0
                 );
             }
             return null;


### PR DESCRIPTION
### Description

At this point in time, if an MDG-Legacy user attempts to target a Minecraft version that does not include a patch number *(or rather does not explicitly set it to 0)*, such as 1.20, 1.19, or 1.18, they will encounter the following exception:

```
java.lang.IllegalArgumentException: Unknown result: intermediaryToNamedMapping. Available results: [compiled, clientResources, sources, compiledWithNeoForge, serverResources, vanillaDeobfuscated, sourcesAndCompiledWithNeoForge, sourcesAndCompiled, sourcesWithNeoForge]
	at net.neoforged.neoform.runtime.engine.NeoFormEngine.createResults(NeoFormEngine.java:537)
	at net.neoforged.neoform.runtime.cli.RunNeoFormCommand.execute(RunNeoFormCommand.java:299)
	at net.neoforged.neoform.runtime.cli.RunNeoFormCommand.runWithNeoFormEngine(RunNeoFormCommand.java:213)
	at net.neoforged.neoform.runtime.cli.NeoFormEngineCommand.call(NeoFormEngineCommand.java:89)
	at net.neoforged.neoform.runtime.cli.NeoFormEngineCommand.call(NeoFormEngineCommand.java:21)
```

This issue stems from `MinecraftReleaseVersion` failing to handle such cases *(e.g., `MinecraftReleaseVersion.parse("1.20")` returns `null`)*. As a result, comparisons such as `isLessThanOrEqualTo(version, MC_1_20_1)` yield incorrect results, since the method always returns `false` when given a `null` value.

This PR fixes it, allowing MDG-Legacy users to target Forge versions 1.20, 1.19, and 1.18 without any problems.

### Related Issues

Fixes #67