### PR TITLE
[POC] Use Apache Commons Compress for faster zip transfers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,11 @@ idea {
                     programParameters = "download-assets --neoforge net.neoforged:neoforge:20.6.72-beta:userdev --write-properties build/assets.properties --write-json build/assets.json"
                     moduleRef(project, sourceSets.main)
                 }
+                "NeoForm 1.21 (joined) strip only"(Application) {
+                    mainClass = mainClassName
+                    programParameters = "run --dist joined --neoform net.neoforged:neoform:1.21-20240613.152323@zip --write-result=node.stripClient.output.output:build/stripped-client.jar --write-result=node.stripServer.output.output:build/stripped-server.jar"
+                    moduleRef(project, sourceSets.main)
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation 'net.fabricmc:fabric-loom-native:0.2.1'
     implementation 'net.neoforged:srgutils:1.0.10'
     implementation 'net.neoforged.installertools:problems-api:3.0.3'
+    implementation 'org.apache.commons:commons-compress:1.27.1'
     annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
 
     testImplementation platform('org.junit:junit-bom:5.13.2')

--- a/src/main/java/net/neoforged/neoform/runtime/actions/SplitResourcesFromClassesAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/SplitResourcesFromClassesAction.java
@@ -3,6 +3,9 @@ package net.neoforged.neoform.runtime.actions;
 import net.neoforged.neoform.runtime.cache.CacheKeyBuilder;
 import net.neoforged.neoform.runtime.engine.ProcessingEnvironment;
 import net.neoforged.srgutils.IMappingFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedOutputStream;
@@ -18,12 +21,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 /**
  * Copies a Jar file while applying a filename filter.
@@ -81,11 +81,12 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
                     .asMatchPredicate();
         }
 
+        // TODO: new ZipFile is deprecated
         try (var jar = new ZipFile(inputJar.toFile());
              var classesFileOut = new BufferedOutputStream(Files.newOutputStream(classesJar));
              var resourcesFileOut = new BufferedOutputStream(Files.newOutputStream(resourcesJar));
-             var classesJarOut = new JarOutputStream(classesFileOut);
-             var resourcesJarOut = new JarOutputStream(resourcesFileOut);
+             var classesJarOut = new ZipArchiveOutputStream(classesFileOut);
+             var resourcesJarOut = new ZipArchiveOutputStream(resourcesFileOut);
         ) {
             if (generateDistManifestSettings != null) {
                 generateDistSourceManifest(
@@ -98,7 +99,7 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
                 );
             }
 
-            var entries = jar.entries();
+            var entries = jar.getEntries();
             while (entries.hasMoreElements()) {
                 var entry = entries.nextElement();
                 if (entry.isDirectory()) {
@@ -119,11 +120,7 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
 
                 var destinationStream = filename.endsWith(".class") ? classesJarOut : resourcesJarOut;
 
-                destinationStream.putNextEntry(entry);
-                try (var is = jar.getInputStream(entry)) {
-                    is.transferTo(destinationStream);
-                }
-                destinationStream.closeEntry();
+                destinationStream.addRawArchiveEntry(entry, jar.getRawInputStream(entry));
             }
         }
     }
@@ -133,7 +130,7 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
                                                    String otherDistId,
                                                    Path otherDistJarPath,
                                                    Path mappingsPath,
-                                                   JarOutputStream resourcesJarOut) throws IOException {
+                                                   ZipArchiveOutputStream resourcesJarOut) throws IOException {
         var mappings = mappingsPath != null ? IMappingFile.load(mappingsPath.toFile()) : null;
 
         // Use the time-stamp of either of the two input files (whichever is newer)
@@ -152,11 +149,11 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
         addSourceDistEntries(ourFiles, theirFiles, distId, mappings, manifest);
         addSourceDistEntries(theirFiles, ourFiles, otherDistId, mappings, manifest);
 
-        var manifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
+        var manifestEntry = new ZipArchiveEntry(JarFile.MANIFEST_NAME);
         manifestEntry.setTimeLocal(MANIFEST_TIME);
-        resourcesJarOut.putNextEntry(manifestEntry);
+        resourcesJarOut.putArchiveEntry(manifestEntry);
         manifest.write(resourcesJarOut);
-        resourcesJarOut.closeEntry();
+        resourcesJarOut.closeArchiveEntry();
     }
 
     private static void addSourceDistEntries(Set<String> distFiles,
@@ -178,11 +175,11 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
     }
 
     private static Set<String> getFileIndex(ZipFile zipFile) {
-        var result = new HashSet<String>(zipFile.size());
+        var result = new HashSet<String>();
 
-        var entries = zipFile.entries();
+        var entries = zipFile.getEntries();
         while (entries.hasMoreElements()) {
-            ZipEntry entry = entries.nextElement();
+            ZipArchiveEntry entry = entries.nextElement();
             if (!entry.isDirectory()) {
                 result.add(entry.getName());
             }

--- a/src/main/java/net/neoforged/neoform/runtime/actions/SplitResourcesFromClassesAction.java
+++ b/src/main/java/net/neoforged/neoform/runtime/actions/SplitResourcesFromClassesAction.java
@@ -222,6 +222,8 @@ public final class SplitResourcesFromClassesAction extends BuiltInAction {
     @Override
     public void computeCacheKey(CacheKeyBuilder ck) {
         super.computeCacheKey(ck);
+        // TODO: remove :P
+        ck.add("force rerun", "" + Math.random());
         ck.addStrings("deny patterns", denyListPatterns.stream().map(Pattern::pattern).toList());
         if (generateDistManifestSettings != null) {
             ck.add("generate dist manifest - our dist", generateDistManifestSettings.distId);


### PR DESCRIPTION
Unfortunately, the Java stdlib does not offer a way to copy entries from one zip to another without deflating and reinflating them. But with Apache Commons Compress, we can use `destinationStream.addRawArchiveEntry(entry, jar.getRawInputStream(entry));` which avoids the decompression+recompression round-trip.

This is a quick proof of concept, on the two `strip` tasks.

Before:
```
 DONE  Completed stripServer in 1.66s
 DONE  Completed stripClient in 2.81s
```

After:
```
 DONE  Completed stripServer in 0.87s
 DONE  Completed stripClient in 1.09s
```