### PR TITLE
Disable parchment parameters for unobfuscated versions

### DIFF
--- a/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
+++ b/src/main/java/net/neoforged/neoform/runtime/cli/RunNeoFormCommand.java
@@ -128,6 +128,11 @@ public class RunNeoFormCommand extends NeoFormEngineCommand {
                 if (parchmentConflictPrefix != null) {
                     transformSources.addArg("--parchment-conflict-prefix=" + parchmentConflictPrefix);
                 }
+                // Don't rename parameters in versions that aren't obfuscated. This can cause changes in semantics
+                // when suddenly a reference to a parameter refers to a captured local variable instead.
+                if (engine.getGraph().getNode("rename") == null) {
+                    transformSources.addArg("--no-parchment-parameters");
+                }
             };
             // Before 1.20.2, sources were still in SRG, while parchment was defined using Mojang names.
             // Hence, we need to apply Parchment after we remap SRG to Mojang names

--- a/src/main/resources/tools.properties
+++ b/src/main/resources/tools.properties
@@ -1,6 +1,6 @@
 
 # https://projects.neoforged.net/neoforged/javasourcetransformer
-JAVA_SOURCE_TRANSFORMER=net.neoforged.jst:jst-cli-bundle:2.0.5
+JAVA_SOURCE_TRANSFORMER=net.neoforged.jst:jst-cli-bundle:2.0.6
 
 DIFF_PATCH=io.codechicken:DiffPatch:2.0.0.36:all
 


### PR DESCRIPTION
There's semantic changes that arise from renaming parameters now that LVT is preserved.
Renamed parameters may refer to outer local variables.